### PR TITLE
Fix shift flexLoc persistence and enforce schedule flex rules.

### DIFF
--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -150,6 +150,7 @@ class ScheduleController extends Controller
             }
             else
             {
+                $selectedShift = Shift::findOrFail($details['shift']);
                 $schedule = $user->schedule()->firstOrNew([
                     'day' => $day,
                     'month' => $request->month,
@@ -157,8 +158,10 @@ class ScheduleController extends Controller
                 ]);
     
                 $schedule->user_id = $user->id;
-                $schedule->shift_id = $details['shift'];
-                $schedule->flexLoc = $details['flexLoc'] ?? 0;
+                $schedule->shift_id = $selectedShift->id;
+                $schedule->flexLoc = $selectedShift->flexLoc
+                    ? (int) ($details['flexLoc'] ?? 0)
+                    : 0;
                 $schedule->save();                
             }
         }

--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -8,6 +8,11 @@ use Illuminate\Support\Facades\Auth;
 
 class ShiftController extends Controller
 {
+    private function normalizeTime(string $value): string
+    {
+        return strlen($value) === 5 ? "{$value}:00" : $value;
+    }
+
     /**
      * Display a listing of the resource.
      */
@@ -42,21 +47,16 @@ class ShiftController extends Controller
                 'required',
                 'regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/',
             ],
-            'hour_start' => ['required', 'date_format:H:i'],
-            'hour_end' => ['required', 'date_format:H:i'],
+            'hour_start' => ['required', 'regex:/^([01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/'],
+            'hour_end' => ['required', 'regex:/^([01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/'],
+            'flexLoc' => ['required', 'boolean'],
+            'override' => ['required', 'boolean'],
         ]);
 
-        if ($request->flexLoc) {
-            $shiftAttributes['flexLoc'] = true;
-        } else {
-            $shiftAttributes['flexLoc'] = false;
-        }
-
-        if ($request->override) {
-            $shiftAttributes['override'] = true;
-        } else {
-            $shiftAttributes['override'] = false;
-        }
+        $shiftAttributes['flexLoc'] = $request->boolean('flexLoc');
+        $shiftAttributes['override'] = $request->boolean('override');
+        $shiftAttributes['hour_start'] = $this->normalizeTime($shiftAttributes['hour_start']);
+        $shiftAttributes['hour_end'] = $this->normalizeTime($shiftAttributes['hour_end']);
 
         $shift = Shift::create($shiftAttributes);
 
@@ -97,21 +97,16 @@ class ShiftController extends Controller
                 'required',
                 'regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/',
             ],
-            'hour_start' => ['required', 'date_format:H:i'],
-            'hour_end' => ['required', 'date_format:H:i'],
+            'hour_start' => ['required', 'regex:/^([01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/'],
+            'hour_end' => ['required', 'regex:/^([01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/'],
+            'flexLoc' => ['required', 'boolean'],
+            'override' => ['required', 'boolean'],
         ]);
 
-        if (! $request->flexLoc) {
-            $shiftAttributes['flexLoc'] = false;
-        } else {
-            $shiftAttributes['flexLoc'] = true;
-        }
-
-        if (! $request->override) {
-            $shiftAttributes['override'] = false;
-        } else {
-            $shiftAttributes['override'] = true;
-        }
+        $shiftAttributes['flexLoc'] = $request->boolean('flexLoc');
+        $shiftAttributes['override'] = $request->boolean('override');
+        $shiftAttributes['hour_start'] = $this->normalizeTime($shiftAttributes['hour_start']);
+        $shiftAttributes['hour_end'] = $this->normalizeTime($shiftAttributes['hour_end']);
 
         $shift->name = $shiftAttributes['name'];
         $shift->display = $shiftAttributes['display'];

--- a/resources/views/components/form/shiftModal.blade.php
+++ b/resources/views/components/form/shiftModal.blade.php
@@ -78,7 +78,7 @@
                     </div>
                     <div class="mt-2">
                         @if ($shift != null)
-                            <x-form.inputTime id="hour_start" name="hour_start" required :value="$shift->hour_start"></x-form.inputTime>
+                            <x-form.inputTime id="hour_start" name="hour_start" required :value="substr((string) $shift->hour_start, 0, 5)"></x-form.inputTime>
                         @else
                             <x-form.inputTime id="hour_start" name="hour_start" required></x-form.inputTime>
                         @endif
@@ -91,7 +91,7 @@
                     </div>
                     <div class="mt-2">
                         @if ($shift != null)
-                            <x-form.inputTime id="hour_end" name="hour_end" required :value="$shift->hour_end"></x-form.inputTime>
+                            <x-form.inputTime id="hour_end" name="hour_end" required :value="substr((string) $shift->hour_end, 0, 5)"></x-form.inputTime>
                         @else
                             <x-form.inputTime id="hour_end" name="hour_end" required></x-form.inputTime>
                         @endif
@@ -103,10 +103,11 @@
                         <label for="flexLoc" class="block text-sm font-medium leading-6">Flexible Location?</label>
                     </div>
                     <div class="mt-2">
+                        <input type="hidden" name="flexLoc" value="0" />
                         @if($shift != null)
-                            <input name="flexLoc" id="flexLoc" type="checkbox" @if($shift->flexLoc == 1) checked @endif/>
+                            <input name="flexLoc" id="flexLoc" type="checkbox" value="1" @if($shift->flexLoc == 1) checked @endif/>
                         @else
-                            <input name="flexLoc" id="flexLoc" type="checkbox" checked />
+                            <input name="flexLoc" id="flexLoc" type="checkbox" value="1" checked />
                         @endif
                     </div>
                 </div>
@@ -116,10 +117,11 @@
                         <label for="flexLoc" class="block text-sm font-medium leading-6">Overridable?</label>
                     </div>
                     <div class="mt-2">
+                        <input type="hidden" name="override" value="0" />
                         @if($shift != null)
-                            <input name="override" id="override" type="checkbox" @if($shift->override == 1) checked @endif/>
+                            <input name="override" id="override" type="checkbox" value="1" @if($shift->override == 1) checked @endif/>
                         @else
-                            <input name="override" id="override" type="checkbox" checked />
+                            <input name="override" id="override" type="checkbox" value="1" checked />
                         @endif
                     </div>
                 </div>
@@ -127,7 +129,7 @@
 
             <div class="flex justify-between pt-2">
                 <x-button class="bg-green-600 hover:bg-green-900">Save</x-button>
-                <x-button class="bg-red-600 hover:bg-red-900" onclick="closeModal('{{ $modalName }}')">Cancel</x-button>
+                <x-button buttonType="button" class="bg-red-600 hover:bg-red-900" onclick="closeModal('{{ $modalName }}')">Cancel</x-button>
             </div>
         </div>
     </div>

--- a/resources/views/components/modal/feedback.blade.php
+++ b/resources/views/components/modal/feedback.blade.php
@@ -1,3 +1,5 @@
+@props(['details' => null])
+
 @php
     $classes = "py-2 px-4 rounded w-64";
 
@@ -77,5 +79,10 @@
         <div>
             {{ $message }}
         </div>
+        @if ($details)
+            <div class="mt-1 text-xs opacity-90 break-words">
+                {{ $details }}
+            </div>
+        @endif
     </div>
 </div>

--- a/resources/views/shift/index.blade.php
+++ b/resources/views/shift/index.blade.php
@@ -56,11 +56,11 @@
         </x-table.table>
     </div>
 
-    <x-modal.feedback>
-        {{ session('feedback') }}
+    <x-modal.feedback :details="$errors->first()">
+        {{ $errors->any() ? 'savingError' : session('feedback') }}
     </x-modal.feedback>
 
-    @if (session('feedback'))
+    @if (session('feedback') || $errors->any())
         <script>
             document.getElementById("feedbackModal").classList.remove('hidden');
 

--- a/tests/Feature/ScheduleTest.php
+++ b/tests/Feature/ScheduleTest.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Models\Role;
+use App\Models\Shift;
 use App\Models\User;
 use App\Models\Schedule;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
 
 it('can display a schedule', function () {
     Schedule::factory(10)->create();
@@ -27,4 +32,67 @@ it('can create a new user and login', function () {
     Auth::login($user);
 
     expect(Auth::hasUser())->toBeTrue();
+});
+
+it('clears schedule flexLoc when saving to a non-flex shift', function () {
+    $adminRole = Role::create(['name' => 'administrator']);
+    Role::create(['name' => 'manager']);
+    Role::create(['name' => 'user']);
+
+    $admin = User::factory()->create([
+        'role_id' => $adminRole->id,
+    ]);
+
+    $flexShift = Shift::factory()->create([
+        'name' => 'F',
+        'display' => 'Flexible',
+        'hour_start' => '08:00:00',
+        'hour_end' => '16:00:00',
+        'flexLoc' => 1,
+    ]);
+
+    $fixedShift = Shift::factory()->create([
+        'name' => 'N',
+        'display' => 'Non Flex',
+        'hour_start' => '09:00:00',
+        'hour_end' => '17:00:00',
+        'flexLoc' => 0,
+    ]);
+
+    $user = User::factory()->create([
+        'role_id' => $adminRole->id,
+    ]);
+
+    Schedule::factory()->create([
+        'user_id' => $user->id,
+        'day' => 1,
+        'month' => 1,
+        'year' => 2026,
+        'shift_id' => $flexShift->id,
+        'flexLoc' => 1,
+    ]);
+
+    $response = $this->actingAs($admin)->patch("/schedule/{$user->id}/update", [
+        'user_id' => $user->id,
+        'month' => 1,
+        'year' => 2026,
+        'shift' => [
+            1 => [
+                'shift' => (string) $fixedShift->id,
+                // Simulates stale checkbox value still sent from UI.
+                'flexLoc' => 1,
+            ],
+        ],
+    ]);
+
+    $response->assertRedirect('/schedule/2026/1');
+
+    $entry = Schedule::where('user_id', $user->id)
+        ->where('day', 1)
+        ->where('month', 1)
+        ->where('year', 2026)
+        ->firstOrFail();
+
+    expect($entry->shift_id)->toBe($fixedShift->id)
+        ->and($entry->flexLoc)->toBe(0);
 });

--- a/tests/Feature/ShiftManagementTest.php
+++ b/tests/Feature/ShiftManagementTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use App\Models\Role;
+use App\Models\Shift;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function shiftPayload(array $overrides = []): array
+{
+    return array_merge([
+        'name' => 'M',
+        'display' => 'Morning Shift',
+        'color' => '#112233',
+        'textColor' => '#FFFFFF',
+        'hour_start' => '08:00',
+        'hour_end' => '16:00',
+    ], $overrides);
+}
+
+it('updates a shift and persists flexLoc when checkbox is unchecked', function () {
+    $adminRole = Role::create(['name' => 'administrator']);
+    Role::create(['name' => 'manager']);
+    Role::create(['name' => 'user']);
+
+    $admin = User::factory()->create([
+        'role_id' => $adminRole->id,
+    ]);
+
+    $shift = Shift::factory()->create([
+        'name' => 'E',
+        'display' => 'Evening Shift',
+        'color' => '#000000',
+        'textColor' => '#FFFFFF',
+        'hour_start' => '14:00',
+        'hour_end' => '22:00',
+        'flexLoc' => true,
+        'override' => true,
+    ]);
+
+    $response = $this->actingAs($admin)->patch(
+        route('shifts.update', $shift->id),
+        shiftPayload([
+            'flexLoc' => '0',
+            'override' => '0',
+        ])
+    );
+
+    $response->assertRedirect('/shiftManagement');
+    $shift->refresh();
+
+    expect($shift->flexLoc)->toBe(0)
+        ->and($shift->override)->toBe(0);
+});
+
+it('updates a shift and persists flexLoc when checkbox is checked', function () {
+    $adminRole = Role::create(['name' => 'administrator']);
+    Role::create(['name' => 'manager']);
+    Role::create(['name' => 'user']);
+
+    $admin = User::factory()->create([
+        'role_id' => $adminRole->id,
+    ]);
+
+    $shift = Shift::factory()->create([
+        'hour_start' => '10:00',
+        'hour_end' => '18:00',
+        'flexLoc' => false,
+        'override' => false,
+    ]);
+
+    $response = $this->actingAs($admin)->patch(
+        route('shifts.update', $shift->id),
+        shiftPayload([
+            'flexLoc' => '1',
+            'override' => '1',
+        ])
+    );
+
+    $response->assertRedirect('/shiftManagement');
+    $shift->refresh();
+
+    expect($shift->flexLoc)->toBe(1)
+        ->and($shift->override)->toBe(1);
+});
+
+it('updates a shift when time values include seconds', function () {
+    $adminRole = Role::create(['name' => 'administrator']);
+    Role::create(['name' => 'manager']);
+    Role::create(['name' => 'user']);
+
+    $admin = User::factory()->create([
+        'role_id' => $adminRole->id,
+    ]);
+
+    $shift = Shift::factory()->create([
+        'hour_start' => '09:00:00',
+        'hour_end' => '17:00:00',
+        'flexLoc' => true,
+        'override' => true,
+    ]);
+
+    $response = $this->actingAs($admin)->patch(
+        route('shifts.update', $shift->id),
+        shiftPayload([
+            'hour_start' => '10:15:00',
+            'hour_end' => '18:45:00',
+            'flexLoc' => '0',
+            'override' => '0',
+        ])
+    );
+
+    $response->assertRedirect('/shiftManagement');
+    $shift->refresh();
+
+    expect($shift->hour_start)->toContain('10:15')
+        ->and($shift->hour_end)->toContain('18:45')
+        ->and($shift->flexLoc)->toBe(0)
+        ->and($shift->override)->toBe(0);
+});


### PR DESCRIPTION
Normalize shift form checkbox/time handling, surface validation errors in feedback toasts, and ensure schedule entries clear flexLoc when assigned to non-flex shifts; add comprehensive feature coverage for shift editing and schedule save behavior.

Made-with: Cursor